### PR TITLE
Add Vapi AI Assistant widget properly

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
+
+// Import styles
 import './styles/reset.css'
 import './styles/variables.css'
 import './styles/header.css'
@@ -8,8 +10,21 @@ import './styles/footer.css'
 import './styles/landing.css'
 import './index.css'
 
+// Mount React app
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-      <App />
+    <App />
   </React.StrictMode>,
 )
+
+// Add Vapi AI Widget dynamically after the app loads
+const vapiScript = document.createElement("script");
+vapiScript.src = "https://unpkg.com/@vapi-ai/client-sdk-react/dist/embed/widget.umd.js";
+vapiScript.async = true;
+vapiScript.type = "text/javascript";
+document.body.appendChild(vapiScript);
+
+const vapiWidget = document.createElement("vapi-widget");
+vapiWidget.setAttribute("assistant-id", "00e14023-bdf9-41c2-b9ad-dee6af725b84");
+vapiWidget.setAttribute("public-key", "246057c7-3986-48a1-a9ae-afa85e9caa85");
+document.body.appendChild(vapiWidget);


### PR DESCRIPTION
This update embeds the Vapi AI chat widget directly into the React app (src/main.tsx).
It ensures the assistant loads dynamically on every page after render.
Once merged and redeployed, Holly will appear bottom-right across all pages.
